### PR TITLE
【起票】【LINE】AI Chatくんの回答でマークダウン形式の見出しが使用されると見切れる

### DIFF
--- a/src/converter/converters/HeadingConverter.ts
+++ b/src/converter/converters/HeadingConverter.ts
@@ -37,6 +37,7 @@ export class HeadingConverter implements FlexConverter {
           type: "text",
           text,
           weight: "bold",
+          wrap: true,
           size
         }
       ],


### PR DESCRIPTION
見出しのコンポーネントに `wrap` のプロパティの追加を行いました。

ざっとEnd2Endで他にも `wrap` できてないコンポーネントがないか試したのですが、一旦他は問題なさそうでした。（テーブルだけコンポーネントが複雑なので不安は残りますが）