### PR TITLE
【起票】【LINE】AIChatくんの回答で「””」がマークダウン形式だと&quotになる

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+    "printWidth": 100,
+    "trailingComma": "es5"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-flex-message",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-flex-message",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@line/bot-sdk": "^8.4.0",

--- a/src/converter/converters/CodeConverter.ts
+++ b/src/converter/converters/CodeConverter.ts
@@ -2,6 +2,7 @@ import { Tokens } from "marked"
 import { FlexSpan, FlexText } from "@line/bot-sdk"
 import { CodeHighlightTheme, FlexConverter, KnownFlexComponent } from "../../types"
 import { CodeParser } from "../../code/CodeParser"
+import { decodeText } from "../../lib/decodeText"
 
 export class CodeConverter implements FlexConverter {
   private readonly parser: CodeParser
@@ -93,7 +94,7 @@ export class CodeConverter implements FlexConverter {
       contents: [
         {
           type: "text",
-          text,
+          text: decodeText(text),
           color: this.theme.titleTextColor,
           size: "xs"
         }

--- a/src/converter/converters/HeadingConverter.ts
+++ b/src/converter/converters/HeadingConverter.ts
@@ -1,5 +1,6 @@
 import { Tokens } from "marked"
 import { FlexConverter, KnownFlexComponent } from "../../types"
+import { decodeText } from "../../lib/decodeText"
 
 function getInnerText(token: Tokens.Generic): string {
   return token.tokens
@@ -35,7 +36,7 @@ export class HeadingConverter implements FlexConverter {
       contents: [
         {
           type: "text",
-          text,
+          text: decodeText(text),
           weight: "bold",
           size
         }

--- a/src/converter/converters/InlineConverter.ts
+++ b/src/converter/converters/InlineConverter.ts
@@ -1,6 +1,7 @@
 import { Token } from "marked"
 import { MainConverter } from "../MainConverter"
 import { KnownFlexComponent } from "../../types"
+import { decodeText } from "../../lib/decodeText"
 
 export class InlineConverter {
   async convert(tokens: Token[]): Promise<KnownFlexComponent[]> {
@@ -31,6 +32,7 @@ export class InlineConverter {
             if (block.contents.length === 0) {
               component.text = (component.text || '').replace(/^\n/, "")
             }
+            component.text = decodeText(component.text || "")
             block.contents.push(component)
           } else {
             components.push(component)

--- a/src/lib/decodeText.ts
+++ b/src/lib/decodeText.ts
@@ -1,0 +1,8 @@
+export function decodeText(text: string): string {
+  return text.replace(/&quot;/g, '"')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, ' ')
+}

--- a/src/tests/MarkdownLineFlex.test.ts
+++ b/src/tests/MarkdownLineFlex.test.ts
@@ -227,3 +227,19 @@ describe('convertToFlexBox', () => {
     }
   })
 })
+
+describe('MarkdownFlexMessage#convert', () => {
+  it('markdown_decode', async () => {
+    const markdown = await fsPromises.readFile(join(dir, '17markdown_decode.md'), 'utf-8')
+    const json = await fsPromises.readFile(join(dir, '17markdown_decode.json'), 'utf-8')
+    const { flexBox, textType } = await convertToFlexBox(markdown)
+    console.log(JSON.stringify(flexBox, null, 2))
+    console.log(textType)
+    if (process.env.DEBUG) {
+      console.log(JSON.stringify(flexBox, null, 2))
+    } else {
+      expect(textType).toEqual('markdown')
+      expect(flexBox).toEqual(JSON.parse(json))
+    }
+  })
+})

--- a/src/tests/resources/markdown/17markdown_decode.json
+++ b/src/tests/resources/markdown/17markdown_decode.json
@@ -1,0 +1,227 @@
+{
+  "type": "box",
+  "layout": "vertical",
+  "spacing": "md",
+  "contents": [
+    {
+      "type": "box",
+      "layout": "vertical",
+      "contents": [
+        {
+          "type": "text",
+          "text": "Testing \"Quoted Heading\" & Symbols",
+          "weight": "bold",
+          "wrap": true,
+          "size": "xl"
+        }
+      ],
+      "paddingBottom": "lg"
+    },
+    {
+      "type": "box",
+      "layout": "vertical",
+      "contents": [
+        {
+          "type": "text",
+          "text": "Heading with 'Single Quotes' Test",
+          "weight": "bold",
+          "wrap": true,
+          "size": "lg"
+        }
+      ],
+      "paddingBottom": "md"
+    },
+    {
+      "type": "box",
+      "layout": "vertical",
+      "contents": [
+        {
+          "type": "text",
+          "text": "Nested \"Quote 'Structure' Testing\" & More",
+          "weight": "bold",
+          "wrap": true,
+          "size": "md"
+        }
+      ],
+      "paddingBottom": "sm"
+    },
+    {
+      "type": "box",
+      "layout": "horizontal",
+      "margin": "md",
+      "contents": [
+        {
+          "type": "box",
+          "layout": "vertical",
+          "width": "4px",
+          "height": "4px",
+          "backgroundColor": "#666979",
+          "cornerRadius": "2px",
+          "offsetTop": "12px",
+          "offsetStart": "4px",
+          "contents": []
+        },
+        {
+          "type": "box",
+          "layout": "vertical",
+          "paddingStart": "12px",
+          "contents": [
+            {
+              "type": "text",
+              "wrap": true,
+              "contents": [
+                {
+                  "type": "span",
+                  "text": "List item with \"quotes\" & symbols"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "box",
+      "layout": "horizontal",
+      "contents": [
+        {
+          "type": "box",
+          "layout": "vertical",
+          "width": "4px",
+          "height": "4px",
+          "backgroundColor": "#666979",
+          "cornerRadius": "2px",
+          "offsetTop": "12px",
+          "offsetStart": "4px",
+          "contents": []
+        },
+        {
+          "type": "box",
+          "layout": "vertical",
+          "paddingStart": "12px",
+          "contents": [
+            {
+              "type": "text",
+              "wrap": true,
+              "contents": [
+                {
+                  "type": "span",
+                  "text": "Item with 'single quotes' & marks"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "box",
+      "layout": "horizontal",
+      "contents": [
+        {
+          "type": "box",
+          "layout": "vertical",
+          "width": "4px",
+          "height": "4px",
+          "backgroundColor": "#666979",
+          "cornerRadius": "2px",
+          "offsetTop": "12px",
+          "offsetStart": "4px",
+          "contents": []
+        },
+        {
+          "type": "box",
+          "layout": "vertical",
+          "paddingStart": "12px",
+          "contents": [
+            {
+              "type": "text",
+              "wrap": true,
+              "contents": [
+                {
+                  "type": "span",
+                  "text": "Mixed \"outer 'inner' quotes\" test"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "box",
+      "layout": "horizontal",
+      "contents": [
+        {
+          "type": "box",
+          "layout": "vertical",
+          "width": "4px",
+          "height": "4px",
+          "backgroundColor": "#666979",
+          "cornerRadius": "2px",
+          "offsetTop": "12px",
+          "offsetStart": "4px",
+          "contents": []
+        },
+        {
+          "type": "box",
+          "layout": "vertical",
+          "paddingStart": "12px",
+          "contents": [
+            {
+              "type": "text",
+              "wrap": true,
+              "contents": [
+                {
+                  "type": "span",
+                  "text": "With "
+                },
+                {
+                  "type": "span",
+                  "text": "`inline \"quoted\" & 'marked' code`",
+                  "weight": "bold",
+                  "size": "sm"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "wrap": true,
+      "contents": [
+        {
+          "type": "span",
+          "text": "Testing "
+        },
+        {
+          "type": "span",
+          "text": "italic \"quotes\" & symbols",
+          "style": "italic"
+        },
+        {
+          "type": "span",
+          "text": " and "
+        },
+        {
+          "type": "span",
+          "text": "bold 'quotes' & marks",
+          "weight": "bold"
+        },
+        {
+          "type": "span",
+          "text": "\nFinal test of "
+        },
+        {
+          "type": "span",
+          "text": "`code with \"double\" & 'single' quotes & symbols`",
+          "weight": "bold",
+          "size": "sm"
+        }
+      ]
+    }
+  ],
+  "paddingAll": "none"
+}

--- a/src/tests/resources/markdown/17markdown_decode.md
+++ b/src/tests/resources/markdown/17markdown_decode.md
@@ -1,0 +1,11 @@
+# Testing "Quoted Heading" & Symbols
+## Heading with 'Single Quotes' Test
+#### Nested "Quote 'Structure' Testing" & More
+
+* List item with "quotes" & symbols
+* Item with 'single quotes' & marks
+* Mixed "outer 'inner' quotes" test
+* With `inline "quoted" & 'marked' code`
+
+Testing _italic "quotes" & symbols_ and **bold 'quotes' & marks**
+Final test of `code with "double" & 'single' quotes & symbols`


### PR DESCRIPTION
## 原因

大元の原因はparserの `marked`ライブラリの`lexer` による。
通常は問題ないが、リストの中で `"` や `'` を使うなど、階層が深くなると`&quot;` などエンコードされてしまうみたい

## 解決方法

`decodeText` 関数を定義

最終的なtextを入れるときに、decodeTextを通して `"` などに戻した上で出力

## テスト

簡単なテストケースを作成しました。また、視覚的にみたい時は

https://developers.line.biz/flex-simulator/?status=success

これでお試しください！

## その他

prettier系の設定入れました